### PR TITLE
Add user roles permissions scraping

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,8 @@ HARDCODED = []
 # Phase 1: User roles list & scrape
 urs.switch_to_admin_role(driver)
 urs.navigate_to_user_roles_list(driver)
+results = urs.scrape_all_user_roles(driver)
+urs.save_permissions(results)
 
 # Phase 3: Scrape workflows
 # all_actions = []


### PR DESCRIPTION
## Summary
- add scraping of permission tables across all user roles
- save permissions in CSV
- invoke scraping from `main.py`

## Testing
- `python -m py_compile user_roles_scraper.py main.py workflow_scraper.py crawler.py`

------
https://chatgpt.com/codex/tasks/task_e_68837f0c0cc48333ad703f926018f036