### PR TITLE
Fix headless mode variable usage

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -7,10 +7,16 @@ import time  # For delays
 from urllib.parse import urljoin  # Handle URLs
 import requests  # requests for HTTP requests
 from bs4 import BeautifulSoup  # Parses HTML to extract links
-from config import NETSUITE_URL, NETSUITE_EMAIL, NETSUITE_PASSWORD, SECURITY_ANSWER, ADMIN_ITEM_URL, HEADLESS_MODE  # Import credentials
+from config import (
+    NETSUITE_URL,
+    NETSUITE_EMAIL,
+    NETSUITE_PASSWORD,
+    SECURITY_ANSWER,
+    ADMIN_ITEM_URL,
+    HEADLESS_MODE,
+)  # Import credentials
 
 # ✅ Configure WebDriver (Allow headless mode)
-HEADLESS_MODE = HEADLESS_MODE # Set to True to run in headless mode
 
 # Set up WebDriver options
 # options = webdriver.ChromeOptions()

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ import workflow_scraper as ws
 import user_roles_scraper as urs
 
 # ✅ Configure WebDriver (Allow headless mode)
-HEADLESS_MODE = HEADLESS_MODE # Set to True to run in headless mode
 
 # Set up WebDriver options
 options = webdriver.ChromeOptions()


### PR DESCRIPTION
## Summary
- remove redundant `HEADLESS_MODE` variable redefinition
- rely on the config constant when setting Chrome options

## Testing
- `python -m py_compile crawler.py main.py user_roles_scraper.py workflow_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6883cfbaa65c833395a347043223a14b