### PR TITLE
Add scraping for Reports and Lists subtabs

### DIFF
--- a/user_roles_scraper.py
+++ b/user_roles_scraper.py
@@ -112,6 +112,8 @@ def scrape_permissions_for_role(driver, role_name, results):
     logger.info(f"  🔍 Scraping permissions for role: {role_name}")
     sections = [
         ("Transactions", "tranmach", "tranmach_splits", 2),
+        ("Reports", "repomach", "repomach_splits", 2),
+        ("Lists", "listsmach", "listsmach_splits", 2),
         ("Setup", "setupmach", "setupmach_splits", 2),
         ("Custom Record", "custrecordmach", "custrecordmach_splits", 3),
     ]


### PR DESCRIPTION
## Summary
- extend permission scraper to capture Reports and Lists subtabs

## Testing
- `python -m py_compile user_roles_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6883d78c47a88333890d8021358ac3e1