### PR TITLE
Add list values scraper and CSV export

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,6 +63,9 @@ HARDCODED = []
 # Phase 1: User roles list & scrape
 lvs.switch_to_admin_role(driver)
 lvs.navigate_to_list_values_table(driver)
+# Scrape and save list values
+list_values = lvs.scrape_list_values(driver)
+lvs.save_list_values(list_values)
 # results = urs.scrape_all_user_roles(driver)
 # urs.save_permissions(results)
 


### PR DESCRIPTION
## Summary
- scrape list values by visiting each list and collecting name data
- add helper to save scraped list values to CSV
- wire new scraping helpers into main workflow

## Testing
- `python -m py_compile list_values_scraper.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6897e0fd43088333a66894be520d0325