### PR TITLE
refactor: centralize admin role switching

### DIFF
--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,0 +1,53 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time
+import logging
+from config import HEADLESS_MODE
+
+logger = logging.getLogger(__name__)
+
+def switch_to_admin_role(driver, role_url):
+    """Switch the current session to an administrator role, handling 2FA if necessary.
+
+    Parameters
+    ----------
+    driver : selenium.webdriver
+        The active WebDriver instance.
+    role_url : str
+        URL for switching to the desired role.
+    """
+    logger.info("➡️ Switching to admin role…")
+    driver.get(role_url)
+
+    if "loginchallenge/entry.nl" in getattr(driver, "current_url", ""):
+        logger.info("🔐 2FA Authentication Required!")
+
+        if HEADLESS_MODE:
+            two_fa_code = input("🔢 Enter 2FA Code: ")
+            try:
+                WebDriverWait(driver, 15).until(
+                    EC.presence_of_element_located((By.ID, "uif56_input"))
+                )
+                two_fa_input = driver.find_element(By.ID, "uif56_input")
+                two_fa_input.send_keys(two_fa_code)
+
+                WebDriverWait(driver, 10).until(
+                    EC.presence_of_element_located((By.CSS_SELECTOR, "div[data-type='primary'][role='button']"))
+                )
+                submit_button = driver.find_element(
+                    By.CSS_SELECTOR, "div[data-type='primary'][role='button']"
+                )
+                driver.execute_script("arguments[0].click();", submit_button)
+                logger.info("✅ 2FA Code Submitted.")
+                time.sleep(5)
+            except Exception as e:  # pragma: no cover - real browser failures
+                logger.error(f"⚠️ Error entering 2FA code: {e}")
+                driver.quit()
+                return
+        else:
+            logger.info("⏳ Waiting for manual 2FA entry in the browser…")
+            time.sleep(30)
+
+    WebDriverWait(driver, 10).until(EC.url_contains("whence"))
+    logger.info("🔄 Switched to admin role.")

--- a/list_values_scraper.py
+++ b/list_values_scraper.py
@@ -6,63 +6,21 @@ import time
 import csv
 import logging
 import re
-from config import HEADLESS_MODE
+from auth_utils import switch_to_admin_role as _switch_to_admin_role
 
 logger = logging.getLogger(__name__)
 
 # ── Phase 1: List Values Navigation & Scrape ─────────────────────────────
+ADMIN_ROLE_URL = (
+    "https://4891605.app.netsuite.com/app/login/secure/changerole.nl?id=4891605~19522~1073~N"
+)
+
+
 def switch_to_admin_role(driver):
     """Switch the current session to an administrator role, handling 2FA if
     necessary."""
 
-    url = (
-        "https://4891605.app.netsuite.com/app/login/secure/changerole.nl?id=4891605~19522~1073~N"
-    )
-    logger.info("➡️ Switching to admin role…")
-    driver.get(url)
-    
-    # ✅ Handle 2FA Authentication
-    if "loginchallenge/entry.nl" in driver.current_url:
-        print("🔐 2FA Authentication Required!")
-
-        if HEADLESS_MODE:
-            # Headless Mode → Enter 2FA Code in Console
-            two_fa_code = input("🔢 Enter 2FA Code: ")  # Prompt user for 6-digit code
-
-            try:
-                # Wait for the 2FA input field
-                WebDriverWait(driver, 15).until(
-                    EC.presence_of_element_located((By.ID, "uif56_input"))
-                )
-
-                # Enter the 2FA code from the console
-                two_fa_input = driver.find_element(By.ID, "uif56_input")
-                two_fa_input.send_keys(two_fa_code)
-                print("✅ 2FA Code Entered.")
-
-                # Wait for the submit button
-                WebDriverWait(driver, 10).until(
-                    EC.presence_of_element_located((By.CSS_SELECTOR, "div[data-type='primary'][role='button']"))
-                )
-
-                # Click submit using JavaScript (since it's inside a <div>)
-                submit_button = driver.find_element(By.CSS_SELECTOR, "div[data-type='primary'][role='button']")
-                driver.execute_script("arguments[0].click();", submit_button)
-                logger.info("✅ 2FA Code Submitted.")
-
-                time.sleep(5)  # Wait for redirection
-            except Exception as e:
-                logger.error(f"⚠️ Error entering 2FA code: {e}")
-                driver.quit()
-                return
-
-        else:
-            # Non-Headless Mode → User enters 2FA manually
-            logger.info("⏳ Waiting for manual 2FA entry in the browser…")
-            time.sleep(30)  # Give user 30 seconds to enter the code manually
-            
-    WebDriverWait(driver, 10).until(EC.url_contains("whence"))
-    logger.info("🔄 Switched to admin role.")
+    _switch_to_admin_role(driver, ADMIN_ROLE_URL)
 
 
 def navigate_to_list_values_table(driver):

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -1,0 +1,77 @@
+import os
+import sys
+from unittest.mock import Mock
+import types
+
+# Ensure the repository root is on the path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Provide a dummy config module for auth_utils
+sys.modules['config'] = types.SimpleNamespace(HEADLESS_MODE=True)
+import auth_utils
+
+
+class DummyWait:
+    def __init__(self, driver, timeout):
+        self.driver = driver
+        self.timeout = timeout
+
+    def until(self, method):
+        return True
+
+
+def test_switch_to_admin_role_headless(monkeypatch):
+    driver = Mock()
+
+    def get(url):
+        driver.current_url = "https://example.com/loginchallenge/entry.nl"
+
+    driver.get.side_effect = get
+    two_input = Mock()
+    submit_button = Mock()
+
+    def find_element(by, value):
+        if value == "uif56_input":
+            return two_input
+        if value == "div[data-type='primary'][role='button']":
+            return submit_button
+        return Mock()
+
+    driver.find_element.side_effect = find_element
+    driver.execute_script = Mock()
+    driver.quit = Mock()
+
+    monkeypatch.setattr(auth_utils, "HEADLESS_MODE", True)
+    monkeypatch.setattr(auth_utils, "WebDriverWait", DummyWait)
+    monkeypatch.setattr("builtins.input", lambda _: "123456")
+    sleep_mock = Mock()
+    monkeypatch.setattr(auth_utils.time, "sleep", sleep_mock)
+
+    auth_utils.switch_to_admin_role(driver, "role_url")
+
+    driver.get.assert_called_once_with("role_url")
+    two_input.send_keys.assert_called_once_with("123456")
+    driver.execute_script.assert_called_once_with("arguments[0].click();", submit_button)
+    sleep_mock.assert_called_once_with(5)
+    driver.quit.assert_not_called()
+
+
+def test_switch_to_admin_role_non_headless(monkeypatch):
+    driver = Mock()
+
+    def get(url):
+        driver.current_url = "https://example.com/loginchallenge/entry.nl"
+
+    driver.get.side_effect = get
+    driver.find_element = Mock()
+
+    monkeypatch.setattr(auth_utils, "HEADLESS_MODE", False)
+    monkeypatch.setattr(auth_utils, "WebDriverWait", DummyWait)
+    sleep_mock = Mock()
+    monkeypatch.setattr(auth_utils.time, "sleep", sleep_mock)
+
+    auth_utils.switch_to_admin_role(driver, "role_url")
+
+    driver.get.assert_called_once_with("role_url")
+    sleep_mock.assert_called_once_with(30)
+    driver.find_element.assert_not_called()

--- a/user_roles_scraper.py
+++ b/user_roles_scraper.py
@@ -6,63 +6,21 @@ import time
 import csv
 import logging
 import re
-from config import HEADLESS_MODE
+from auth_utils import switch_to_admin_role as _switch_to_admin_role
 
 logger = logging.getLogger(__name__)
 
 # ── Phase 1: User Roles Navigation & Scrape ─────────────────────────────
+ADMIN_ROLE_URL = (
+    "https://4891605.app.netsuite.com/app/login/secure/changerole.nl?id=4891605~19522~1073~N"
+)
+
+
 def switch_to_admin_role(driver):
     """Switch the current session to an administrator role, handling 2FA if
     necessary."""
 
-    url = (
-        "https://4891605.app.netsuite.com/app/login/secure/changerole.nl?id=4891605~19522~1073~N"
-    )
-    logger.info("➡️ Switching to admin role…")
-    driver.get(url)
-    
-    # ✅ Handle 2FA Authentication
-    if "loginchallenge/entry.nl" in driver.current_url:
-        print("🔐 2FA Authentication Required!")
-
-        if HEADLESS_MODE:
-            # Headless Mode → Enter 2FA Code in Console
-            two_fa_code = input("🔢 Enter 2FA Code: ")  # Prompt user for 6-digit code
-
-            try:
-                # Wait for the 2FA input field
-                WebDriverWait(driver, 15).until(
-                    EC.presence_of_element_located((By.ID, "uif56_input"))
-                )
-
-                # Enter the 2FA code from the console
-                two_fa_input = driver.find_element(By.ID, "uif56_input")
-                two_fa_input.send_keys(two_fa_code)
-                print("✅ 2FA Code Entered.")
-
-                # Wait for the submit button
-                WebDriverWait(driver, 10).until(
-                    EC.presence_of_element_located((By.CSS_SELECTOR, "div[data-type='primary'][role='button']"))
-                )
-
-                # Click submit using JavaScript (since it's inside a <div>)
-                submit_button = driver.find_element(By.CSS_SELECTOR, "div[data-type='primary'][role='button']")
-                driver.execute_script("arguments[0].click();", submit_button)
-                logger.info("✅ 2FA Code Submitted.")
-
-                time.sleep(5)  # Wait for redirection
-            except Exception as e:
-                logger.error(f"⚠️ Error entering 2FA code: {e}")
-                driver.quit()
-                return
-
-        else:
-            # Non-Headless Mode → User enters 2FA manually
-            logger.info("⏳ Waiting for manual 2FA entry in the browser…")
-            time.sleep(30)  # Give user 30 seconds to enter the code manually
-            
-    WebDriverWait(driver, 10).until(EC.url_contains("whence"))
-    logger.info("🔄 Switched to admin role.")
+    _switch_to_admin_role(driver, ADMIN_ROLE_URL)
 
 
 def navigate_to_user_roles_list(driver):


### PR DESCRIPTION
## Summary
- add `auth_utils.switch_to_admin_role` helper handling 2FA and role URL
- use shared 2FA helper in user and list scrapers
- add tests covering headless vs. non-headless 2FA flows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689856734dcc8333b3c0393bc646389a