### PR TITLE
Use first column anchor in list values scraper

### DIFF
--- a/list_values_scraper.py
+++ b/list_values_scraper.py
@@ -44,9 +44,9 @@ def scrape_list_values(driver):
     links = []
     for row in rows:
         try:
-            name = row.find_element(By.CSS_SELECTOR, 'td[data-label="Name"]').text.strip()
-            last_td = row.find_elements(By.CSS_SELECTOR, "td")[-1]
-            href = last_td.find_element(By.TAG_NAME, "a").get_attribute("href")
+            link = row.find_element(By.CSS_SELECTOR, "td:first-child a")
+            name = link.text.strip()
+            href = link.get_attribute("href")
             links.append((name, href))
         except NoSuchElementException:
             continue
@@ -59,7 +59,7 @@ def scrape_list_values(driver):
         values = [
             cell.text.strip()
             for cell in driver.find_elements(
-                By.CSS_SELECTOR, 'tr.uir-list-row-tr td[data-label="Name"]'
+                By.CSS_SELECTOR, "tr.uir-list-row-tr td:first-child"
             )
             if cell.text.strip()
         ]


### PR DESCRIPTION
## Summary
- parse list value rows using the first-column anchor for both name and link
- remove `td[data-label="Name"]` selectors in list value extraction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689884b923188333896a6e08f547a017