### PR TITLE
Scrape list values from second column of customvalue rows

### DIFF
--- a/list_values_scraper.py
+++ b/list_values_scraper.py
@@ -61,14 +61,19 @@ def scrape_list_values(driver):
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located((By.ID, "customvalue_splits"))
         )
-        values = [
-            cell.text.strip()
-            for cell in driver.find_elements(
-                By.CSS_SELECTOR,
-                "#customvalue_splits tr.uir-list-row-tr td:first-child",
-            )
-            if cell.text.strip()
-        ]
+        rows = driver.find_elements(
+            By.CSS_SELECTOR, '#customvalue_splits tr[id^="customvalue_row_"]'
+        )
+        values = []
+        for row in rows:
+            try:
+                value = row.find_element(
+                    By.CSS_SELECTOR, 'td:nth-child(2)'
+                ).text.strip()
+                if value:
+                    values.append(value)
+            except NoSuchElementException:
+                continue
         results[name] = values
 
     logger.info("✅ Finished scraping list values.")


### PR DESCRIPTION
## Summary
- Scrape list values by iterating `#customvalue_splits tr[id^="customvalue_row_"]` and reading each row's second cell
- Map collected values to their corresponding list names

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898930011348333a60cb4673e8df0f4