### PR TITLE
Add run helpers and dispatcher for NetSuite scrapers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,20 +62,29 @@ HEADLESS_MODE = False  # Change to True to run without opening a browser
 
 ## 🚀 **Running the Crawler**
 
-### **Normal Mode (With Browser)**
+Choose one or more scrapers to run using the `--scrapers` flag. Scrapers run
+sequentially after a single login.
+
+Available scrapers:
+
+- `crawler`
+- `workflows`
+- `user-roles`
+- `list-values`
+
+### **Examples**
+
+Scrape list values and user roles:
 
 ```sh
-python main.py
+python main.py --scrapers list-values,user-roles
 ```
-Running the script logs in and **scrapes permissions for all user roles**. The
-results are saved to `user_role_permissions.csv` in the project directory.
 
-#### **NB: This only applies to user accounts with Administrative Privileges**
+Scrape workflows for specific record types:
 
-- You manually enter the 2FA code in the browser when prompted.
-- The bot automatically iterates through the role list and exports the CSV.
-
----
+```sh
+python main.py --scrapers workflows --records '["Admin Request","Feedback"]'
+```
 
 ### **Headless Mode (Without Browser)**
 
@@ -85,18 +94,12 @@ Edit config.py and set:
 HEADLESS_MODE = True
 ```
 
-Then run:
-
-```sh
-python main.py
-```
-The process is the same as normal mode, but the browser window stays hidden. The
-script prompts you for the 2FA code in the console and then scrapes all role
-permissions automatically.
+Use the same command-line options; the browser runs hidden and prompts you in
+the terminal for the 2FA code.
 
 #### **NB: This only applies to user accounts with Administrative Privileges**
 
-- Provide the 2FA code when prompted in the terminal.
+- Provide the 2FA code when prompted.
 
 ---
 

--- a/crawler.py
+++ b/crawler.py
@@ -167,5 +167,14 @@ def crawl_netsuite(driver):
     print("\n✅ Crawling complete!")
     print(f"Total Links Found: {len(visited)}")
     print("\n".join(visited))
+    return visited
 
-    driver.quit()  # ✅ Close browser after crawling is finished
+
+def run(driver):
+    """Run the standalone site crawler.
+
+    Assumes ``driver`` is already logged into NetSuite.  Returns the set of
+    visited links for further processing if needed.
+    """
+
+    return crawl_netsuite(driver)

--- a/list_values_scraper.py
+++ b/list_values_scraper.py
@@ -115,3 +115,12 @@ def save_list_values(data, filename="list_values.csv"):
                 writer.writerow([list_name, value])
 
     logger.info(f"💾 Saved list values to {filename}")
+
+
+def run(driver):
+    """Run the list-values scraper end to end."""
+
+    switch_to_admin_role(driver)
+    navigate_to_list_values_table(driver)
+    data = scrape_list_values(driver)
+    save_list_values(data)

--- a/user_roles_scraper.py
+++ b/user_roles_scraper.py
@@ -179,3 +179,12 @@ def save_permissions(results, filename="user_role_permissions.csv"):
         writer.writerow(["Role", "Section", "Permission/Record", "Level", "Restrict"])
         writer.writerows(results)
     logger.info(f"📂 Saved user role permissions to {filename}")
+
+
+def run(driver):
+    """Run the complete user-role scraping workflow."""
+
+    switch_to_admin_role(driver)
+    navigate_to_user_roles_list(driver)
+    results = scrape_all_user_roles(driver)
+    save_permissions(results)

--- a/workflow_scraper.py
+++ b/workflow_scraper.py
@@ -569,3 +569,32 @@ def save_actions(results, filename="workflow_actions.csv"):
         writer.writerow(["Record Type","Workflow","State","Category","Trigger","Action","Arguments","Condition"])
         writer.writerows(results)
     print(f"📂 Saved actions to {filename}")
+
+
+def run(driver, records=None):
+    """Orchestrate the workflow scraping process.
+
+    Parameters
+    ----------
+    driver: selenium.webdriver
+        Active WebDriver instance, already logged into NetSuite.
+    records: list[str] | None
+        Optional list of record type names.  When omitted, the list is
+        extracted dynamically from the HRA role.
+    """
+
+    if records is None:
+        switch_to_hra_role(driver)
+        records = extract_hra_record_types(driver)
+
+    switch_to_admin_role(driver)
+
+    all_actions = []
+    for rec in records:
+        navigate_to_workflow_list(driver)
+        if filter_by_record_type(driver, rec):
+            scrape_workflow_for_record(driver, rec, all_actions)
+        else:
+            print(f"➡️ Skipping {rec}")
+
+    save_actions(all_actions)


### PR DESCRIPTION
## Summary
- add `run()` helper functions to each scraper module for easier orchestration
- introduce a dispatcher in `main.py` controlled by a new `--scrapers` CLI flag
- document the new interface and usage examples in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c68a79148333885d4cb125429a5d