### PR TITLE
docs: document scraper output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Available scrapers:
 - `user-roles`
 - `list-values`
 
+### Default Output Files
+
+Each scraper saves its results to a CSV file in the project root:
+
+- `list-values` → **`list_values.csv`**, containing custom list IDs, names, and their associated values.
+- `user-roles` → **`user_role_permissions.csv`**, capturing each role's permissions across transactions, reports, lists, and setup categories.
+- `workflows` → **`workflow_actions.csv`**, listing workflow names, record types, and their associated actions.
+
 ### **Examples**
 
 Scrape list values and user roles:


### PR DESCRIPTION
## Summary
- document default CSV output for list-values, user-roles, and workflows scrapers

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898fe740d5c83338a9f65d83eda0518