### PR TITLE
Add tests for crawler extract_links

### DIFF
--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import types
+import requests
+
+# Ensure repository root on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Provide dummy config module required by crawler
+sys.modules['config'] = types.SimpleNamespace(
+    NETSUITE_URL='',
+    NETSUITE_EMAIL='',
+    NETSUITE_PASSWORD='',
+    SECURITY_ANSWER='',
+    ADMIN_ITEM_URL='',
+    HEADLESS_MODE=True,
+)
+
+import crawler
+
+
+class MockDriver:
+    def __init__(self, html):
+        self.page_source = html
+        self.get_called_with = None
+
+    def get(self, url):
+        self.get_called_with = url
+
+
+def test_extract_links_fallback_to_selenium(monkeypatch):
+    """requests.get raises, so extract_links should use Selenium's page_source."""
+    def mock_get(url, timeout):
+        raise requests.RequestException("failure")
+
+    monkeypatch.setattr(crawler.requests, "get", mock_get)
+    monkeypatch.setattr(crawler.time, "sleep", lambda _: None)
+
+    html = '<html><body><a href="/page">Link</a></body></html>'
+    driver = MockDriver(html)
+
+    links = crawler.extract_links(driver, "https://example.com")
+
+    assert driver.get_called_with == "https://example.com"
+    assert links == {"https://example.com/page"}
+
+
+def test_extract_links_unique_absolute_urls(monkeypatch):
+    """When requests.get succeeds, unique absolute URLs are returned."""
+    html = (
+        '<html><body>'
+        '<a href="/page1">Page1</a>'
+        '<a href="/page1">Duplicate</a>'
+        '<a href="https://example.com/page2">Page2</a>'
+        '</body></html>'
+    )
+
+    class Response:
+        def __init__(self, text):
+            self.text = text
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(crawler.requests, "get", lambda url, timeout: Response(html))
+
+    links = crawler.extract_links(None, "https://example.com")
+
+    assert links == {"https://example.com/page1", "https://example.com/page2"}


### PR DESCRIPTION
## Summary
- add tests verifying extract_links falls back to Selenium when requests fails
- ensure extract_links returns unique absolute URLs when requests succeeds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899118ea0d8833384544d9dc2f9e00e