### PR TITLE
docs: remove PowerShell example

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,6 @@ vary by terminal:
 python main.py --scrapers workflows --records '["Admin Request","Feedback"]'
 ```
 
-**PowerShell:**
-
-```powershell
-python main.py --scrapers workflows --records "[`"Admin Request`",`"Feedback`"]"
-```
-
 **cmd.exe:**
 
 ```cmd


### PR DESCRIPTION
## Summary
- remove incorrect PowerShell usage in README examples for workflow record types

## Testing
- `python -m pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899938e78d48333a3c5a0bc425eb3f4