### PR TITLE
docs: remove PowerShell example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,7 @@ Dispatch scrapers from `main.py`:
 python main.py --scrapers workflows,user-roles
 ```
 To provide record types for the workflow scraper, pass JSON via `--records`.
-PowerShell example:
-```powershell
-python .\main.py --scrapers workflows --records '["Sales Order", "Purchase Order"]'
-```
+PowerShell is not officially supported; use Bash or cmd instead.
 
 ## Output
 Scrapers write CSV files (`user_role_permissions.csv`, `list_values.csv`, etc.) to the current working directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,18 @@ python main.py --scrapers workflows,user-roles
 To provide record types for the workflow scraper, pass JSON via `--records`.
 PowerShell is not officially supported; use Bash or cmd instead.
 
+**bash (Linux/macOS):**
+
+```bash
+python main.py --scrapers workflows --records '["Admin Request","Feedback"]'
+```
+
+**cmd.exe:**
+
+```cmd
+python main.py --scrapers workflows --records "[\"Admin Request\",\"Feedback\"]"
+```
+
 ## Output
 Scrapers write CSV files (`user_role_permissions.csv`, `list_values.csv`, etc.) to the current working directory.
 


### PR DESCRIPTION
## Summary
- remove PowerShell example from scraper instructions
- note that PowerShell isn't supported; use bash or cmd instead

## Testing
- `python -m pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b551bad48333b973c4d98f7cdd1f