### PR TITLE
Add HARDCODED record override for workflow scraping

### DIFF
--- a/workflow_scraper.py
+++ b/workflow_scraper.py
@@ -10,6 +10,8 @@ import re
 from bs4 import BeautifulSoup
 from config import SECURITY_ANSWER, HEADLESS_MODE
 
+HARDCODED: list[str] = []  # e.g., ["Admin Request", "Feedback"]
+
 # ── Phase 1: HRA Record Types Extraction ────────────────────────────────────
 def switch_to_hra_role(driver):
     url = "https://4891605.app.netsuite.com/app/login/secure/changerole.nl?id=4891605~18903~1059~N"
@@ -584,8 +586,11 @@ def run(driver, records=None):
     """
 
     if records is None:
-        switch_to_hra_role(driver)
-        records = extract_hra_record_types(driver)
+        if HARDCODED:
+            records = HARDCODED
+        else:
+            switch_to_hra_role(driver)
+            records = extract_hra_record_types(driver)
 
     switch_to_admin_role(driver)
 


### PR DESCRIPTION
## Summary
- define a module-level HARDCODED record list
- prefer HARDCODED records when no records are supplied to the workflow scraper

## Testing
- `python -m pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b993b8388333921e329d7717c28f