### PR TITLE
docs: note HARDCODED workflow records

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ python main.py --scrapers workflows --records '["Admin Request","Feedback"]'
 python main.py --scrapers workflows --records "[\"Admin Request\",\"Feedback\"]"
 ```
 
+For quick runs you can pre-populate `workflow_scraper.HARDCODED` with a list of
+record names. This list is used whenever `--records` is not passed:
+
+```python
+# workflow_scraper.py
+HARDCODED: list[str] = ["Admin Request", "Feedback"]
+```
+
 ### **Headless Mode (Without Browser)**
 
 Edit config.py and set:


### PR DESCRIPTION
## Summary
- document how to pre-populate `workflow_scraper.HARDCODED` for quick workflow runs when `--records` is not supplied

## Testing
- `python -m pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6899c563989083338a9de7b14709c0ef